### PR TITLE
EC2のDBをRDSに切り替える

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -51,6 +51,6 @@ production:
   <<: *default
   database: breakin_community_production
   username: root
-  password: <%= ENV['DATABASE_PASSWORD'] %>
+  password: <%= ENV['RDSDATABASE_PASSWORD'] %>
+  host: <%= ENV['RDSDATABASE_HOST'] %>
   socket: /var/lib/mysql/mysql.sock
-


### PR DESCRIPTION
# What
MariaDBからAWS上で作成したRDSのDBインスタンスに移行する 
# Why
DBを安定して運用しデータの消失を防ぐため