### PR TITLE
練習場所の投稿編集機能の向上

### DIFF
--- a/app/assets/stylesheets/places/index.css.erb
+++ b/app/assets/stylesheets/places/index.css.erb
@@ -22,7 +22,7 @@
 }
 
 .place {
-  font-size:32px;
+  font-size:25px;
   font-weight:bold;
   position: relative;
   padding:8px;

--- a/app/assets/stylesheets/places/new.css.erb
+++ b/app/assets/stylesheets/places/new.css.erb
@@ -34,7 +34,7 @@
 }
 
 .new-name-text {
-  font-size:24px;
+  font-size:20px;
   width:30%;
   line-height:80px;
   text-align:left;
@@ -65,7 +65,7 @@
 }
 
 .new-address-text {
-  font-size:24px;
+  font-size:20px;
   width:30%;
   line-height:80px;
   text-align:left;
@@ -94,7 +94,7 @@
 }
 
 .new-remark-text {
-  font-size:24px;
+  font-size:20px;
   width:30%;
   line-height:80px;
   text-align:left;
@@ -119,7 +119,7 @@
 }
 
 .new-price-text {
-  font-size:24px;
+  font-size:20px;
   width:30%;
   line-height:80px;
   text-align:left;
@@ -153,7 +153,7 @@
 }
 
 .new-image-text {
-  font-size:24px;
+  font-size:20px;
   width:50%;
   line-height:80px;
   text-align:left;
@@ -199,12 +199,12 @@
 
 .map-contents {
   width:calc(100% - 700px);
-  height:100%;
+  height:700px;
 }
 
 #newTarget {
   width: 90%;
-  height: 400px;
+  height: 500px;
 }
 
 @media (max-width: 599px) {

--- a/app/javascript/newmap.js
+++ b/app/javascript/newmap.js
@@ -21,15 +21,8 @@ function newMap() {
           map: map,
           animation: google.maps.Animation.DROP,
         });
-        const infoWindow = new google.maps.InfoWindow({
-          content: e.latLng.toString("style", "color:black;")
-        });
-        marker.addListener('click', function() {
-          infoWindow.open(map, marker);
-          infoWindow.content.setAttribute();
-        placeAddress.innerHTML = results[0].formatted_address;
-        });
         // placeAddress.innerHTML = results[0].geometry.location;
+        placeAddress.innerHTML = results[0].formatted_address;
         document.getElementById('lat').value=results[0].geometry.location.lat();
         document.getElementById('lng').value=results[0].geometry.location.lng();
         placeAddress.innerHTML = results[0].formatted_address;

--- a/app/models/place.rb
+++ b/app/models/place.rb
@@ -13,8 +13,8 @@ class Place < ApplicationRecord
   has_many :user_places, dependent: :destroy
   has_many :users, through: :user_places
   accepts_nested_attributes_for :user_places # place保存にuser_placeも保存される
-  # validates :lat, numericality: { greater_than_or_equal_to:  -90, less_than_or_equal_to:  90 }
-  # validates :lng, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
+  validates :lat, numericality: { greater_than_or_equal_to:  -90, less_than_or_equal_to:  90 }
+  validates :lng, numericality: { greater_than_or_equal_to: -180, less_than_or_equal_to: 180 }
 
   has_one_attached :image
   validate :image_content_type, if: :was_attached?

--- a/app/views/places/edit.html.erb
+++ b/app/views/places/edit.html.erb
@@ -1,5 +1,15 @@
 <%= render "shared/header" %> 
 <div class="new-contents">
+  <div class="map-contents">
+    <div class="content">
+    <div class="place">マップにマーカーを立てて練習場所を編集する</div>
+      <div id="newTarget"></div><%#地図を表示%>
+      <form class= "search">
+        <input type="text" id="address">
+        <input type=submit id="search" onClick="return false;" value="Search">
+      </form>
+    </div>
+  </div>
   <div class="contents">
     <%= form_with model: @place, url: place_path, local: true do |f| %>
       <%= render 'error_messages', place: @place %>
@@ -53,6 +63,8 @@
           </div>
         </div>
         <input name="place[user_ids][]" type="hidden" value=<%=current_user.id%> >
+        <input name="place[lat]" type= "hidden" id="lat" value=<%=@place.lat%> >
+        <input name="place[lng]" type= "hidden" id="lng" value=<%=@place.lng%> >
         <%= f.submit "変更する！" %>
         <%=link_to 'もどる', root_path%>
       </div>

--- a/app/views/places/new.html.erb
+++ b/app/views/places/new.html.erb
@@ -1,5 +1,15 @@
 <%= render "shared/header" %> 
 <div class="new-contents">
+  <div class="map-contents">
+    <div class="content">
+    <div class="place">マップにマーカーを立てて新しい練習場所を登録する</div>
+      <div id="newTarget"></div><%#地図を表示%>
+      <form class= "search">
+        <input type="text" id="address">
+        <input type=submit id="search" onClick="return false;" value="Search">
+      </form>
+    </div>
+  </div>
   <div class="contents">
     <%= form_with model: @place, url: places_path, local: true do |f| %>
       <%= render 'error_messages', place: @place %>
@@ -17,7 +27,7 @@
             練習場所の住所
           </div>
           <div class="new-address-form">
-            <%= f.text_area :address, placeholder:"（必須 )\nGoogleMapで検索できる地名でないと登録できません", maxlength:"40" %>
+            <%= f.text_area :address, placeholder:"（必須 )\nGoogleMapをクリックしてみましょう", maxlength:"40" %>
           </div>
         </div>
         <div class="new-price">
@@ -53,21 +63,12 @@
           </div>
         </div>
         <input name="place[user_ids][]" type="hidden" value=<%=current_user.id%>>
-        <input name="place[lats][]" type= "hidden" id="lat" >
-        <input name="place[lngs][]" type= "hidden" id="lng" >
+        <input name="place[lat]" type= "hidden" id="lat" >
+        <input name="place[lng]" type= "hidden" id="lng" >
         <%= f.submit "新しい練習場所を登録する！" %>
         <%=link_to 'もどる', root_path%>
       </div>
     <% end %>
-  </div>
-  <div class="map-contents">
-    <div class="content">
-      <div id="newTarget"></div><%#地図を表示%>
-      <form class= "search">
-        <input type="text" id="address">
-        <input type=submit id="search" onClick="return false;" value="Search">
-      </form>
-    </div>
   </div>
 </div>
 <%= render "shared/footer" %> 

--- a/spec/models/place_spec.rb
+++ b/spec/models/place_spec.rb
@@ -65,26 +65,26 @@ RSpec.describe Place, type: :model do
         @place.valid?
         expect(@place.errors.full_messages).to include '備考欄は80文字以内で入力してください'
       end
-      # it 'latが-90より小さいと登録できない' do
-      #   @place.lat = -90.1
-      #   @place.valid?
-      #   expect(@place.errors.full_messages).to include '緯度は-90以上の値にしてください'
-      # end
-      # it 'latが90より大きいと登録できない' do
-      #   @place.lat = 90.1
-      #   @place.valid?
-      #   expect(@place.errors.full_messages).to include '緯度は90以下の値にしてください'
-      # end
-      # it 'lngが-180より小さいと登録できない' do
-      #   @place.lng = -180.1
-      #   @place.valid?
-      #   expect(@place.errors.full_messages).to include '経度は-180以上の値にしてください'
-      # end
-      # it 'lngが180より大きいと登録できない' do
-      #   @place.lng = 180.1
-      #   @place.valid?
-      #   expect(@place.errors.full_messages).to include '経度は180以下の値にしてください'
-      # end
+      it 'latが-90より小さいと登録できない' do
+        @place.lat = -90.1
+        @place.valid?
+        expect(@place.errors.full_messages).to include '緯度は-90以上の値にしてください'
+      end
+      it 'latが90より大きいと登録できない' do
+        @place.lat = 90.1
+        @place.valid?
+        expect(@place.errors.full_messages).to include '緯度は90以下の値にしてください'
+      end
+      it 'lngが-180より小さいと登録できない' do
+        @place.lng = -180.1
+        @place.valid?
+        expect(@place.errors.full_messages).to include '経度は-180以上の値にしてください'
+      end
+      it 'lngが180より大きいと登録できない' do
+        @place.lng = 180.1
+        @place.valid?
+        expect(@place.errors.full_messages).to include '経度は180以下の値にしてください'
+      end
       it 'imageの拡張子は.jpeg, .jpg, .gif, .png, .bmp以外では登録できないこと' do
         @place.image = fixture_file_upload('app/assets/images/test.eps')
         @place.valid?


### PR DESCRIPTION
# What
・練習場所の新規登録ページで緯度経度も保存されるようにする
・練習場所の編集ページで緯度経度も保存されるようにする
・練習場所の新規登録ページでinfowindowをなくしマーカー表示のみにする
・練習場所の編集ページでinfowindowをなくしマーカー表示のみにする
# Why
#45 で発生していたエラーを解消し、練習場所の新規登録、編集のUI/UXを向上させる